### PR TITLE
add 'tail call' mode support

### DIFF
--- a/trace.lua
+++ b/trace.lua
@@ -164,7 +164,7 @@ local function hook(var , level)
 			if call == level then
 				debug.sethook(f,'crl')
 			end
-		elseif mode == 'call' then
+		elseif mode == 'call' or mode == 'tail call' then
 			setname(2)
 			call = call + 1
 			if call > level then


### PR DESCRIPTION
原来版本没有支持mode 为tail call的，导致尾调用时 没有正确处理。例如以下代码
test2.lua:
```
local M = {}
function M.test2()
    print("test2"); --这里应该输出./test2.lua     :       3，原来的代码输出 test.lua        :       3
end

return M
```
test.lua
```
local trace = require "trace"

local test2 = require "test2"

local function test1()
    print("test1")
    return test2.test2()
end
trace.trace("", 3)
test1()
```



